### PR TITLE
Fixed algorithm header

### DIFF
--- a/src/auth/mech-digest-md5.c
+++ b/src/auth/mech-digest-md5.c
@@ -106,8 +106,8 @@ static string_t *get_digest_challenge(struct digest_auth_request *request)
 	}
 	str_append(str, "\",");
 
-	str_append(str, "charset=\"utf-8\","
-		   "algorithm=\"md5-sess\"");
+	str_append(str, "charset=utf-8,"
+		   "algorithm=md5-sess");
 	return str;
 }
 


### PR DESCRIPTION
In the original file there was a misunderstanding of  RFC spec, that is clearly represented on example at the end of the RFC https://tools.ietf.org/html/rfc2831
algorithm         = "algorithm" "=" "md5-sess" 
should be seen as  **algorithm=md5-sess**,charset=utf-8 
while
realm             = "realm" "=" <"> realm-value <"> 
is literally with ""quotes  **realm="elwood.innosoft.com"**

The presence of quotes in the original file was causing issues with Iphone email clients